### PR TITLE
Update demo

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -287,6 +287,10 @@ The LUME-services model template is pre-configured to publish the container imag
 
 2.  In the left sidebar, click `Secrets`, `Actions`, then `New repository secret`. Type `DOCKER_USERNAME` into the name, and your DockerHub username into the value and click `Add secret` to save. Repeat this process to create a `DOCKER_PASSWORD` secret with your DockerHub password as the value.  
 
+
+3.  In the left sidebar, click the top level `Actions` (not the one under `Secrets`), and choose `General`. Go to the `Workflow permissions` section
+and select `Read and write permissions`. This will allow the workflow triggered by a new release to publish your model to your repository.
+
 ### 10. Create a release
 
 Create a tagged release for your model. Navigate to `https://github.com/<your GitHub username>/my-model/releases` -> `Draft a new release`
@@ -325,6 +329,12 @@ Configure your environment variables.
 source docs/examples/demo.env
 ```
 
+Ensure docker has the ability to bind mount files from your conda environment. If using docker desktop, go to Preferences -> Resources -> File Sharing
+and ensure the path to `/opt/miniconda3/envs/my-model-dev/lib/python3.9/site-packages/lume_services` is included within your
+rules (adjusting the path to your local installation as necessary). If this path is not available to docker, then you will likely
+encounter `Error response from daemon: invalid mount config for type "bind": bind source path does not exist` when attempting to start
+up lume-services below.
+
 If you are using the Stanford Container Registry, you'll have to set additional environment variables, you `STANFORD_USERNAME` and `SCR_PAT` from step 9.
 ```
 export STANFORD_USERNAME=<your_stanford_username>
@@ -358,5 +368,5 @@ source docs/examples/demo.env
 ```
 Open the demo notebook and continue the remainder of the demo by running each cell:
 ```
-jupyter notebook docs/examples/Demo.ipynb
+jupyter lab docs/examples/Demo.ipynb
 ```

--- a/lume_services/docker/files/docker-compose.yml
+++ b/lume_services/docker/files/docker-compose.yml
@@ -149,7 +149,7 @@ services:
     # This configures access to services
     command: >
       bash -c "prefect server create-tenant --name default --slug default &>/dev/null ;
-      [[ -n ${STANFORD_USERNAME} && -n ${SCR_PAT} ]] && docker login -u ${STANFORD_USERNAME} -p ${SCR_PAT} http://scr.svc.stanford.edu;
+      [[ -n \"${STANFORD_USERNAME}\" && -n \"${SCR_PAT}\" ]] && docker login -u ${STANFORD_USERNAME} -p ${SCR_PAT} http://scr.svc.stanford.edu;
       prefect agent docker start --label lume-services --agent-address http://localhost:5000/ --show-flow-logs --log-level DEBUG --network service-net --env LUME_BACKEND=$LUME_BACKEND
       --env LUME_MOUNTED_FILESYSTEM__IDENTIFIER=${LUME_MOUNTED_FILESYSTEM__IDENTIFIER:-mounted}
       --env LUME_MOUNTED_FILESYSTEM__MOUNT_PATH=${LUME_MOUNTED_FILESYSTEM__MOUNT_PATH}

--- a/lume_services/models/model.py
+++ b/lume_services/models/model.py
@@ -227,13 +227,13 @@ class Model(BaseModel):
                 group="orchestration", name=f"{deployment.package_import_name}.model"
             )
             if len(model_entrypoint):
-                model_type = model_entrypoint[0].load()
+                model_type = model_entrypoint[f"{deployment.package_import_name}.model"].load()
 
             flow_entrypoint = dist.entry_points.select(
                 group="orchestration", name=f"{deployment.package_import_name}.flow"
             )
             if len(flow_entrypoint):
-                flow.prefect_flow = flow_entrypoint[0].load()
+                flow.prefect_flow = flow_entrypoint[f"{deployment.package_import_name}.flow"].load()
 
             else:
                 raise NoFlowFoundInPackageError(deployment.package_import_name)
@@ -274,8 +274,9 @@ class Model(BaseModel):
         flow_entrypoint = dist.entry_points.select(
             group="orchestration", name=f"{source.name}.flow"
         )
+
         if len(flow_entrypoint):
-            prefect_flow = flow_entrypoint[0].load()
+            prefect_flow = flow_entrypoint[f"{source.name}.flow"].load()
 
         else:
             raise NoFlowFoundInPackageError(source_path)


### PR DESCRIPTION
Adds a bit of extra documentation to the demo for a few issues encountered while running it.

- Build would not be added to the release without correct permissions for the workflow
- Docker needs to be able to bind mount `model-db-init.sql`
- Run with jupyter lab instead of notebook as notebook is not installed by default as part of these instructions

Also fixes an issue where the prefect command in docker compose doesn't work properly if `STANFORD_USERNAME` or `SCR_PAT` aren't set

```
bash: -c: line 1: unexpected argument `&&' to conditional unary operator
bash: -c: line 1: syntax error near `&'
bash: -c: line 1: `prefect server create-tenant --name default --slug default &>/dev/null ; [[ -n  && -n  ]] && docker login -u  -
```

And fixes access to entry point elements.